### PR TITLE
Fix metadata timestamp and dependencies

### DIFF
--- a/modules/metadata_builder.py
+++ b/modules/metadata_builder.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import time
 from datetime import timedelta
 
 # Assuming these modules exist and have the specified functions
@@ -58,7 +59,7 @@ def build_media_metadata(video_path, subtitle_path=None, output_dir='movie/metad
     metadata = {
         "media_file": os.path.basename(video_path),
         "subtitle_file": os.path.basename(subtitle_path) if subtitle_path else None,
-        "processed_at": os.strftime("%Y-%m-%d %H:%M:%S"),
+        "processed_at": time.strftime("%Y-%m-%d %H:%M:%S"),
         "filters_applied": {
             "profanity": filters.get('profanity', {}).get('enabled', False),
             "nudity": filters.get('nudity', {}).get('enabled', False),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@
 # Example dependencies (you'll add more as your project grows)
 # For GUI
 Pillow
-tk
+# Tkinter comes bundled with Python; no separate package needed
 # For media processing (placeholders, actual libraries might vary)
 opencv-python-headless # For video processing
-pysrt                  # For subtitle parsing
+srt                    # For subtitle parsing
 PyYAML                 # For YAML configuration
 # For potential AI models (example, replace with actual)
 tensorflow


### PR DESCRIPTION
## Summary
- import `time` in `metadata_builder`
- switch to `time.strftime` for metadata timestamps
- clean up dependency list in `requirements.txt`

## Testing
- `PYTHONPATH=. python modules/metadata_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_6850647f8efc8323952919a7a380f3ec